### PR TITLE
fix: use published supertest version

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "supertest": "^6.4.2",
+    "supertest": "^6.3.3",
     "tsx": "^4.7.0",
     "typescript": "^5.4.5",
     "vitest": "^1.5.1"


### PR DESCRIPTION
## Summary
- update the API package to reference a published supertest version

## Testing
- npm install (fails: npm error 403 Forbidden - GET https://registry.npmjs.org/concurrently)


------
https://chatgpt.com/codex/tasks/task_e_68d86fe329d083319c1fe2c953896e9e